### PR TITLE
Fixes syntax error in lockclient.py

### DIFF
--- a/lockclient.py
+++ b/lockclient.py
@@ -400,7 +400,7 @@ class LockClient(Sender):
                 if (
                     key not in self.RPs[RP].settings[laser]
                 ):  # do not accidently add another setting!
-                    var input(f"{key} does not exist in settings! Add it? (y/n)")
+                    var = input(f"{key} does not exist in settings! Add it? (y/n)")
                     if var == 'y':
                         pass
                     else:


### PR DESCRIPTION
There is a syntax error in lockclient which prevents importing. This PR fixes it, and allows the example file to run.