### PR TITLE
Allows initialisation of LockClient with no moitor RP set

### DIFF
--- a/lockclient.py
+++ b/lockclient.py
@@ -820,10 +820,13 @@ class LockClient(Sender):
             return
         # get monitor settings, which contains all lasers
         monitor_RP = self.find_monitor_RP(RP)
-        if self.monitors[monitor_RP]["running"].value:
-            self.set_monitor_of_type(monitor_RP, Type="cavity")
-        elif self.monitors[monitor_RP]["running_err"].value:
-            self.set_monitor_of_type(monitor_RP, Type="errors")
+        if monitor_RP is not None:
+            if self.monitors[monitor_RP]["running"].value:
+                self.set_monitor_of_type(monitor_RP, Type="cavity")
+            elif self.monitors[monitor_RP]["running_err"].value:
+                self.set_monitor_of_type(monitor_RP, Type="errors")
+        else:
+            warnings.warn('Tried to set a monitor, but did not find one in the dictionary')
 
     def stop_monitor(self, RP):
         """


### PR DESCRIPTION
We found when running the operation example with no monitor RedPitaya that `set_monitor` would fail. This appears to be a bug, as the doumentation indicates that it should be possible to run while using a separate oscilloscope to monitor the traces.

This pull request address this by making changes to the `set_monitor` method to check if a monitor RP is defined before attempting to retrieve it from the dictionary.